### PR TITLE
fix: set default value None for optional fields so we do not get validation error when the field is missing

### DIFF
--- a/pygrocy2/grocy_api_client.py
+++ b/pygrocy2/grocy_api_client.py
@@ -227,7 +227,7 @@ class BatteryData(BaseModel):
     id: int
     name: str
     description: str | None = None
-    used_in: str
+    used_in: str | None = None
     charge_interval_days: int
     created_timestamp: datetime = Field(alias="row_created_timestamp")
     userfields: dict | None = None

--- a/pygrocy2/grocy_api_client.py
+++ b/pygrocy2/grocy_api_client.py
@@ -111,7 +111,7 @@ class ChoreData(BaseModel):
     assignment_type: str | None = None
     assignment_config: str | None = None
     next_execution_assigned_to_user_id: int | None = None
-    userfields: dict | None
+    userfields: dict | None = None
 
     next_execution_assigned_to_user_id_validator = _field_not_empty_validator(
         "next_execution_assigned_to_user_id"


### PR DESCRIPTION
## Description

After upgrade to pydantic2, optional fields needs to have default value None. Also adds fix for root_validator being replaced by model_validator

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist
  - [x] The code change is tested and works locally.
  - [ ] tests pass. **Your PR won't be merged unless tests pass**
  - [ ] There is no commented out code in this PR
