### PR TITLE
fix(chores): add userfields when getting details

### DIFF
--- a/pygrocy2/data_models/chore.py
+++ b/pygrocy2/data_models/chore.py
@@ -88,6 +88,7 @@ class Chore(DataModel):
     def get_details(self, api_client: GrocyApiClient):
         details = api_client.get_chore(self.id)
         self._init_from_ChoreDetailsResponse(details)
+        self._userfields = api_client.get_userfields( "chores", self.id )
 
     @property
     def id(self) -> int:


### PR DESCRIPTION
## Description

`userfields` is defined as part of the `ChoreData` but its never populated as far as I can tell.
https://github.com/flipper/pygrocy2/blob/dac05fcb11367a062f5f348f5d041e505de36880/pygrocy2/grocy_api_client.py#L102-L118

This PR adds the `userfields` when details are requested.

## Checklist
  - [x] The code change is tested and works locally.
  - [x] tests pass. **Your PR won't be merged unless tests pass**
  - [x] There is no commented out code in this PR

_Note: To pass the tests I had to change the import in `conftest.py` from `from pygrocy2 import Grocy` to `from pygrocy2.grocy import Grocy`. I haven't used tox before nor have I uploaded to PIP so I assume my test environment just had some sort of pathing issue and therefore did not commit that change._ 